### PR TITLE
Update Get-AbrVbrBackupServerInfo.ps1

### DIFF
--- a/Src/Private/Get-AbrVbrBackupServerInfo.ps1
+++ b/Src/Private/Get-AbrVbrBackupServerInfo.ps1
@@ -184,7 +184,7 @@ function Get-AbrVbrBackupServerInfo {
                                         Section -Style Heading4 "HealthCheck - Services Status" {
                                             $OutObj = @()
                                             foreach ($Service in $Services) {
-                                                Write-PscriboMessage "Collecting '$($Service.DisplayName)' status on $($BackupServer.Namr)."
+                                                Write-PscriboMessage "Collecting '$($Service.DisplayName)' status on $($BackupServer.Name)."
                                                 $inObj = [ordered] @{
                                                     'Display Name' = $Service.DisplayName
                                                     'Short Name' = $Service.Name


### PR DESCRIPTION
Fix typo on line 187 ($BackupServer.Namr to $BackupServer.Name)

<!--- Provide a general summary of your changes in the Title above -->

## Description
Fix typo on line 187 ($BackupServer.Namr to $BackupServer.Name)

## Related Issue
(https://github.com/AsBuiltReport/AsBuiltReport.Veeam.VBR/issues/9)

## Motivation and Context
Typo was non-breaking as it only affected the -Verbose output, but should be fixed for completeness.

## How Has This Been Tested?
Tested to confirm that the correct Backup Server name is displayed when using -Vebose output.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/22597403/151941338-08c2c863-57e4-464d-826a-2c09dc79d4d7.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
