### PR TITLE
Update Get-AbrVbrBackupServerInfo.ps1

### DIFF
--- a/Src/Private/Get-AbrVbrBackupServerInfo.ps1
+++ b/Src/Private/Get-AbrVbrBackupServerInfo.ps1
@@ -135,9 +135,9 @@ function Get-AbrVbrBackupServerInfo {
                                             'Partial Product Key' = $License.PartialProductKey
                                             'Manufacturer' = $HW.CsManufacturer
                                             'Model' = $HW.CsModel
-                                            'Serial Number' = $HostBIOS.SerialNumber
+                                            'Serial Number' = $HWBIOS.SerialNumber
                                             'Bios Type' = $HW.BiosFirmwareType
-                                            'BIOS Version' = $HostBIOS.Version
+                                            'BIOS Version' = $HWBIOS.Version
                                             'Processor Manufacturer' = $HWCPU[0].Manufacturer
                                             'Processor Model' = $HWCPU[0].Name
                                             'Number of CPU Cores' = $HWCPU[0].NumberOfCores


### PR DESCRIPTION
Change $HostBIOS to $HWBIOS

Change $HostBIOS to $HWBIOS as $HostBIOS is never defined

## Description
Looks like some refactoring had been done, but a few variables were overlooked.

## Related Issue
(https://github.com/AsBuiltReport/AsBuiltReport.Veeam.VBR/issues/11)

## Motivation and Context
Fixes output of BIOS Serial Number and Version in section 1.1.1.1 Hardware Information for Backup Server

## How Has This Been Tested?
Refactored the variable $HostBIOS to $HWBIOS and re-ran the code and got the correct Serial Number and Version of my BIOS

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
