### PR TITLE
Backup Server physical memory (GB) < 8 always returns true

### DIFF
--- a/Src/Private/Get-AbrVbrBackupProxy.ps1
+++ b/Src/Private/Get-AbrVbrBackupProxy.ps1
@@ -147,9 +147,9 @@ function Get-AbrVbrBackupProxy {
                                                             'Partial Product Key' = $License.PartialProductKey
                                                             'Manufacturer' = $HW.CsManufacturer
                                                             'Model' = $HW.CsModel
-                                                            'Serial Number' = $HostBIOS.SerialNumber
+                                                            'Serial Number' = $HWBIOS.SerialNumber
                                                             'Bios Type' = $HW.BiosFirmwareType
-                                                            'BIOS Version' = $HostBIOS.Version
+                                                            'BIOS Version' = $HWBIOS.Version
                                                             'Processor Manufacturer' = $HWCPU[0].Manufacturer
                                                             'Processor Model' = $HWCPU[0].Name
                                                             'Number of CPU Cores' = $HWCPU[0].NumberOfCores
@@ -160,7 +160,7 @@ function Get-AbrVbrBackupProxy {
 
                                                         if ($HealthCheck.Infrastructure.Server) {
                                                             $OutObj | Where-Object { $_.'Number of CPU Cores' -lt 4} | Set-Style -Style Warning -Property 'Number of CPU Cores'
-                                                            $OutObj | Where-Object { $_.'Physical Memory (GB)' -lt 8} | Set-Style -Style Warning -Property 'Physical Memory (GB)'
+                                                            if ([int]([regex]::Matches($OutObj.'Physical Memory (GB)', "\d+(?!.*\d+)").value) -lt 8) { $OutObj | Set-Style -Style Warning -Property 'Physical Memory (GB)' }
                                                         }
 
                                                         $TableParams = @{
@@ -373,9 +373,9 @@ function Get-AbrVbrBackupProxy {
                                                                 'Partial Product Key' = $License.PartialProductKey
                                                                 'Manufacturer' = $HW.CsManufacturer
                                                                 'Model' = $HW.CsModel
-                                                                'Serial Number' = $HostBIOS.SerialNumber
+                                                                'Serial Number' = $HWBIOS.SerialNumber
                                                                 'Bios Type' = $HW.BiosFirmwareType
-                                                                'BIOS Version' = $HostBIOS.Version
+                                                                'BIOS Version' = $HWBIOS.Version
                                                                 'Processor Manufacturer' = $HWCPU[0].Manufacturer
                                                                 'Processor Model' = $HWCPU[0].Name
                                                                 'Number of CPU Cores' = $HWCPU[0].NumberOfCores
@@ -386,7 +386,7 @@ function Get-AbrVbrBackupProxy {
 
                                                             if ($HealthCheck.Infrastructure.Server) {
                                                                 $OutObj | Where-Object { $_.'Number of CPU Cores' -lt 4} | Set-Style -Style Warning -Property 'Number of CPU Cores'
-                                                                $OutObj | Where-Object { $_.'Physical Memory (GB)' -lt 8} | Set-Style -Style Warning -Property 'Physical Memory (GB)'
+                                                                if ([int]([regex]::Matches($OutObj.'Physical Memory (GB)', "\d+(?!.*\d+)").value) -lt 8) { $OutObj | Set-Style -Style Warning -Property 'Physical Memory (GB)' }
                                                             }
 
                                                             $TableParams = @{

--- a/Src/Private/Get-AbrVbrBackupServerInfo.ps1
+++ b/Src/Private/Get-AbrVbrBackupServerInfo.ps1
@@ -148,7 +148,7 @@ function Get-AbrVbrBackupServerInfo {
 
                                         if ($HealthCheck.Infrastructure.Server) {
                                             $OutObj | Where-Object { $_.'Number of CPU Cores' -lt 4} | Set-Style -Style Warning -Property 'Number of CPU Cores'
-                                            $OutObj | Where-Object { $_.'Physical Memory (GB)' -lt 8} | Set-Style -Style Warning -Property 'Physical Memory (GB)'
+                                            if ([int]([regex]::Matches($OutObj.'Physical Memory (GB)', "\d+(?!.*\d+)").value) -lt 8) { $OutObj | Set-Style -Style Warning -Property 'Physical Memory (GB)' }
                                         }
 
                                         $TableParams = @{


### PR DESCRIPTION
## Description

Due to an error in the way $OutObj.'Physical Memory (GB)' (type = String) gets checked to see if it is less than '8' (type = int32) it will always return $True which ends up with the report incorrectly highlighting the physical memory even when it is greater than 8.

## Related Issue

- Fixes #14


## Motivation and Context

Total physical memory >= 8 GB should not be highlighted with 'Warning' color

## How Has This Been Tested?

- my homelab

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
