### PR TITLE
Add SOBR extent details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # :arrows_clockwise: Veeam VBR As Built Report Changelog
 
+## [0.4.2] - 2022-04-26
+
+- Added detailed repository information of ScaleOut Backup Repository extents
+     - Information of parent SOBR is also included
+
 ## [0.4.1] - 2022-04-24
 
 ### Added

--- a/Src/Private/Get-AbrVbrBackupRepository.ps1
+++ b/Src/Private/Get-AbrVbrBackupRepository.ps1
@@ -36,12 +36,8 @@ function Get-AbrVbrBackupRepository {
                             [Array]$BackupRepos = Get-VBRBackupRepository | Where-Object {$_.Type -ne "SanSnapshotOnly"}
                             [Array]$ScaleOuts = Get-VBRBackupRepository -ScaleOut
                             if ($ScaleOuts) {
-                                foreach ($ScaleOut in $ScaleOuts) {
-                                    $Extents = Get-VBRRepositoryExtent -Repository $ScaleOut
-                                    foreach ($Extent in $Extents) {
-                                        $BackupRepos = $BackupRepos + $Extent.repository
-                                    }
-                                }
+                                {$Extents = Get-VBRRepositoryExtent -Repository $ScaleOuts}
+                                $BackupRepos = $BackupRepos + $Extents.Repository
                             }
                             foreach ($BackupRepo in $BackupRepos) {
                                 Write-PscriboMessage "Discovered $($BackupRepo.Name) Repository."
@@ -94,7 +90,7 @@ function Get-AbrVbrBackupRepository {
                                 Section -Style Heading4 "Backup Repository Configuration" {
                                     Paragraph "The following section provides a detailed information of the Veeam Backup Repository Configuration."
                                     BlankLine
-                                    $BackupRepos = Get-VBRBackupRepository
+  #                                  $BackupRepos = Get-VBRBackupRepository
                                     foreach ($BackupRepo in $BackupRepos) {
                                         try {
                                             Section -Style Heading5 "$($BackupRepo.Name)" {
@@ -103,6 +99,7 @@ function Get-AbrVbrBackupRepository {
                                                 $OutObj = @()
                                                 Write-PscriboMessage "Discovered $($BackupRepo.Name) Backup Repository."
                                                 $inObj = [ordered] @{
+                                                    'Extent of ScaleOut Backup Repository' = (($ScaleOuts | Where-Object {($Extents | Where-Object {$_.name -eq $BackupRepo.Name}).ParentId -eq $_.Id}).Name)
                                                     'Backup Proxy' = ($BackupRepo.Host).Name
                                                     'Integration Type' = $BackupRepo.TypeDisplay
                                                     'Path' = $BackupRepo.Path
@@ -117,6 +114,9 @@ function Get-AbrVbrBackupRepository {
                                                     'Immutability Interval' = $BackupRepo.GetImmutabilitySettings().IntervalDays
                                                     'Version Of Creation' = $BackupRepo.VersionOfCreation
                                                     'Has Backup Chain Length Limitation' = ConvertTo-TextYN $BackupRepo.HasBackupChainLengthLimitation
+                                                }
+                                                if ($null -eq $inObj.'Extent of ScaleOut Backup Repository') {
+                                                    $inObj.Remove('Extent of ScaleOut Backup Repository')
                                                 }
                                                 $OutObj += [pscustomobject]$inobj
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Up to now there were no detailed information about extents of ScaleOut Backup Repositories (SOBR). Now they are part of "Backup Repository Configuration". There is also a new table-entry: "Extent of ScaleOut Backup Repository", when repository is an extent of a SOBR. Otherwise this line isn't visible.
Details:
- shortened (if ($ScaleOuts))-section. So it was easily possible to keep extents-information in array.
- disabled new creation of  $BackupRepos, because it already includes all SOBR-extents.
- adding new line in repository table
- if new line as no entry, remove it afterwards

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
SOBR extents are also normal repositories, so their settings are also interesting.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested in my demo environment

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
