### PR TITLE
Cloud Connect Identification Logic Fix

### DIFF
--- a/AsBuiltReport.Veeam.VBR.psd1
+++ b/AsBuiltReport.Veeam.VBR.psd1
@@ -12,7 +12,7 @@
 RootModule = 'AsBuiltReport.Veeam.VBR.psm1'
 
 # Version number of this module.
-ModuleVersion = '0.8.3'
+ModuleVersion = '0.8.4'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()

--- a/Src/Private/Get-AbrVbrCloudConnectBS.ps1
+++ b/Src/Private/Get-AbrVbrCloudConnectBS.ps1
@@ -5,7 +5,7 @@ function Get-AbrVbrCloudConnectBS {
     .DESCRIPTION
         Documents the configuration of Veeam VBR in Word/HTML/Text formats using PScribo.
     .NOTES
-        Version:        0.7.1
+        Version:        0.7.2
         Author:         Jonathan Colon
         Twitter:        @jcolonfzenpr
         Github:         rebelinux

--- a/Src/Private/Get-AbrVbrCloudConnectBS.ps1
+++ b/Src/Private/Get-AbrVbrCloudConnectBS.ps1
@@ -25,7 +25,7 @@ function Get-AbrVbrCloudConnectBS {
 
     process {
         try {
-            if (Get-VBRInstalledLicense | Where-Object {$_.CloudConnect -in @("Enterprise")}) {
+            if (Get-VBRInstalledLicense | Where-Object {$_.CloudConnect -ne "Disabled"}) {
                 if (((Get-VBRCloudTenant).Resources.Repository).count -gt 0) {
                     $CloudObjects = (Get-VBRCloudTenant).Resources
                     Section -Style Heading3 'Backup Storage' {

--- a/Src/Private/Get-AbrVbrCloudConnectBS.ps1
+++ b/Src/Private/Get-AbrVbrCloudConnectBS.ps1
@@ -5,7 +5,7 @@ function Get-AbrVbrCloudConnectBS {
     .DESCRIPTION
         Documents the configuration of Veeam VBR in Word/HTML/Text formats using PScribo.
     .NOTES
-        Version:        0.7.2
+        Version:        0.8.3
         Author:         Jonathan Colon
         Twitter:        @jcolonfzenpr
         Github:         rebelinux

--- a/Src/Private/Get-AbrVbrCloudConnectCG.ps1
+++ b/Src/Private/Get-AbrVbrCloudConnectCG.ps1
@@ -6,7 +6,7 @@ function Get-AbrVbrCloudConnectCG {
     .DESCRIPTION
         Documents the configuration of Veeam VBR in Word/HTML/Text formats using PScribo.
     .NOTES
-        Version:        0.8.1
+        Version:        0.8.3
         Author:         Jonathan Colon
         Twitter:        @jcolonfzenpr
         Github:         rebelinux

--- a/Src/Private/Get-AbrVbrCloudConnectCG.ps1
+++ b/Src/Private/Get-AbrVbrCloudConnectCG.ps1
@@ -26,7 +26,7 @@ function Get-AbrVbrCloudConnectCG {
 
     process {
         try {
-            if (Get-VBRInstalledLicense | Where-Object {$_.CloudConnect -in @("Enterprise")}) {
+            if (Get-VBRInstalledLicense | Where-Object {$_.CloudConnect -ne "Disabled"}) {
                 if ((Get-VBRCloudGateway).count -gt 0) {
                     Section -Style Heading3 'Cloud Gateways' {
                         Paragraph "The following section provides summary information about configured Cloud Gateways."

--- a/Src/Private/Get-AbrVbrCloudConnectCG.ps1
+++ b/Src/Private/Get-AbrVbrCloudConnectCG.ps1
@@ -6,7 +6,7 @@ function Get-AbrVbrCloudConnectCG {
     .DESCRIPTION
         Documents the configuration of Veeam VBR in Word/HTML/Text formats using PScribo.
     .NOTES
-        Version:        0.8.0
+        Version:        0.8.1
         Author:         Jonathan Colon
         Twitter:        @jcolonfzenpr
         Github:         rebelinux

--- a/Src/Private/Get-AbrVbrCloudConnectCert.ps1
+++ b/Src/Private/Get-AbrVbrCloudConnectCert.ps1
@@ -6,7 +6,7 @@ function Get-AbrVbrCloudConnectCert {
     .DESCRIPTION
         Documents the configuration of Veeam VBR in Word/HTML/Text formats using PScribo.
     .NOTES
-        Version:        0.7.2
+        Version:        0.8.3
         Author:         Jonathan Colon
         Twitter:        @jcolonfzenpr
         Github:         rebelinux

--- a/Src/Private/Get-AbrVbrCloudConnectCert.ps1
+++ b/Src/Private/Get-AbrVbrCloudConnectCert.ps1
@@ -6,7 +6,7 @@ function Get-AbrVbrCloudConnectCert {
     .DESCRIPTION
         Documents the configuration of Veeam VBR in Word/HTML/Text formats using PScribo.
     .NOTES
-        Version:        0.7.1
+        Version:        0.7.2
         Author:         Jonathan Colon
         Twitter:        @jcolonfzenpr
         Github:         rebelinux

--- a/Src/Private/Get-AbrVbrCloudConnectCert.ps1
+++ b/Src/Private/Get-AbrVbrCloudConnectCert.ps1
@@ -26,7 +26,7 @@ function Get-AbrVbrCloudConnectCert {
 
     process {
         try {
-            if (Get-VBRInstalledLicense | Where-Object {$_.CloudConnect -in @("Enterprise")}) {
+            if (Get-VBRInstalledLicense | Where-Object {$_.CloudConnect -ne "Disabled"}) {
                 if ((Get-VBRCloudGatewayCertificate).count -gt 0) {
                     Section -Style Heading3 'Gateway Certificate' {
                         Paragraph "The following section provides information about Cloud Gateways SSL Certificate."

--- a/Src/Private/Get-AbrVbrCloudConnectGP.ps1
+++ b/Src/Private/Get-AbrVbrCloudConnectGP.ps1
@@ -6,7 +6,7 @@ function Get-AbrVbrCloudConnectGP {
     .DESCRIPTION
         Documents the configuration of Veeam VBR in Word/HTML/Text formats using PScribo.
     .NOTES
-        Version:        0.8.0
+        Version:        0.8.1
         Author:         Jonathan Colon
         Twitter:        @jcolonfzenpr
         Github:         rebelinux

--- a/Src/Private/Get-AbrVbrCloudConnectGP.ps1
+++ b/Src/Private/Get-AbrVbrCloudConnectGP.ps1
@@ -6,7 +6,7 @@ function Get-AbrVbrCloudConnectGP {
     .DESCRIPTION
         Documents the configuration of Veeam VBR in Word/HTML/Text formats using PScribo.
     .NOTES
-        Version:        0.8.1
+        Version:        0.8.3
         Author:         Jonathan Colon
         Twitter:        @jcolonfzenpr
         Github:         rebelinux

--- a/Src/Private/Get-AbrVbrCloudConnectGP.ps1
+++ b/Src/Private/Get-AbrVbrCloudConnectGP.ps1
@@ -26,7 +26,7 @@ function Get-AbrVbrCloudConnectGP {
 
     process {
         try {
-            if (Get-VBRInstalledLicense | Where-Object {$_.CloudConnect -in @("Enterprise")}) {
+            if (Get-VBRInstalledLicense | Where-Object {$_.CloudConnect -ne "Disabled"}) {
                 if ((Get-VBRCloudGatewayPool).count -gt 0) {
                     Section -Style Heading3 'Gateways Pools' {
                         Paragraph "The following section provides summary information about configured Cloud Gateways Pools."

--- a/Src/Private/Get-AbrVbrCloudConnectPublicIP.ps1
+++ b/Src/Private/Get-AbrVbrCloudConnectPublicIP.ps1
@@ -6,7 +6,7 @@ function Get-AbrVbrCloudConnectPublicIP {
     .DESCRIPTION
         Documents the configuration of Veeam VBR in Word/HTML/Text formats using PScribo.
     .NOTES
-        Version:        0.7.1
+        Version:        0.7.2
         Author:         Jonathan Colon
         Twitter:        @jcolonfzenpr
         Github:         rebelinux

--- a/Src/Private/Get-AbrVbrCloudConnectPublicIP.ps1
+++ b/Src/Private/Get-AbrVbrCloudConnectPublicIP.ps1
@@ -25,7 +25,7 @@ function Get-AbrVbrCloudConnectPublicIP {
     }
 
     process {
-        if (Get-VBRInstalledLicense | Where-Object {$_.CloudConnect -in @("Enterprise")}) {
+        if (Get-VBRInstalledLicense | Where-Object {$_.CloudConnect -ne "Disabled"}) {
             if ((Get-VBRCloudGatewayPool).count -gt 0) {
                 Section -Style Heading3 'Public IP' {
                     Paragraph "The following section provides information about Cloud Public IP."

--- a/Src/Private/Get-AbrVbrCloudConnectPublicIP.ps1
+++ b/Src/Private/Get-AbrVbrCloudConnectPublicIP.ps1
@@ -6,7 +6,7 @@ function Get-AbrVbrCloudConnectPublicIP {
     .DESCRIPTION
         Documents the configuration of Veeam VBR in Word/HTML/Text formats using PScribo.
     .NOTES
-        Version:        0.7.2
+        Version:        0.8.3
         Author:         Jonathan Colon
         Twitter:        @jcolonfzenpr
         Github:         rebelinux

--- a/Src/Private/Get-AbrVbrCloudConnectRR.ps1
+++ b/Src/Private/Get-AbrVbrCloudConnectRR.ps1
@@ -25,7 +25,7 @@ function Get-AbrVbrCloudConnectRR {
     }
 
     process {
-        if (Get-VBRInstalledLicense | Where-Object {$_.CloudConnect -in @("Enterprise")}) {
+        if (Get-VBRInstalledLicense | Where-Object {$_.CloudConnect -ne "Disabled"}) {
             if ((Get-VBRCloudHardwarePlan).count -gt 0) {
                 Section -Style Heading3 'Replica Resources' {
                     Paragraph "The following table provides a summary of Replica Resources."

--- a/Src/Private/Get-AbrVbrCloudConnectRR.ps1
+++ b/Src/Private/Get-AbrVbrCloudConnectRR.ps1
@@ -6,7 +6,7 @@ function Get-AbrVbrCloudConnectRR {
     .DESCRIPTION
         Documents the configuration of Veeam VBR in Word/HTML/Text formats using PScribo.
     .NOTES
-        Version:        0.7.1
+        Version:        0.7.2
         Author:         Jonathan Colon
         Twitter:        @jcolonfzenpr
         Github:         rebelinux

--- a/Src/Private/Get-AbrVbrCloudConnectRR.ps1
+++ b/Src/Private/Get-AbrVbrCloudConnectRR.ps1
@@ -6,7 +6,7 @@ function Get-AbrVbrCloudConnectRR {
     .DESCRIPTION
         Documents the configuration of Veeam VBR in Word/HTML/Text formats using PScribo.
     .NOTES
-        Version:        0.7.2
+        Version:        0.8.3
         Author:         Jonathan Colon
         Twitter:        @jcolonfzenpr
         Github:         rebelinux

--- a/Src/Private/Get-AbrVbrCloudConnectStatus.ps1
+++ b/Src/Private/Get-AbrVbrCloudConnectStatus.ps1
@@ -6,7 +6,7 @@ function Get-AbrVbrCloudConnectStatus {
     .DESCRIPTION
         Documents the configuration of Veeam VBR in Word/HTML/Text formats using PScribo.
     .NOTES
-        Version:        0.7.2
+        Version:        0.8.3
         Author:         Jonathan Colon
         Twitter:        @jcolonfzenpr
         Github:         rebelinux

--- a/Src/Private/Get-AbrVbrCloudConnectStatus.ps1
+++ b/Src/Private/Get-AbrVbrCloudConnectStatus.ps1
@@ -25,7 +25,7 @@ function Get-AbrVbrCloudConnectStatus {
     }
 
     process {
-        if (Get-VBRInstalledLicense | Where-Object {$_.CloudConnect -in @("Enterprise")}) {
+        if (Get-VBRInstalledLicense | Where-Object {$_.CloudConnect -ne "Disabled"}) {
             if ((Get-VBRCloudInfrastructureState).count -gt 0) {
                 Section -Style Heading3 'Service Status' {
                     Paragraph "The following section provides information about Cloud Gateways SSL Certificate."

--- a/Src/Private/Get-AbrVbrCloudConnectStatus.ps1
+++ b/Src/Private/Get-AbrVbrCloudConnectStatus.ps1
@@ -6,7 +6,7 @@ function Get-AbrVbrCloudConnectStatus {
     .DESCRIPTION
         Documents the configuration of Veeam VBR in Word/HTML/Text formats using PScribo.
     .NOTES
-        Version:        0.7.1
+        Version:        0.7.2
         Author:         Jonathan Colon
         Twitter:        @jcolonfzenpr
         Github:         rebelinux

--- a/Src/Private/Get-AbrVbrCloudConnectTenant.ps1
+++ b/Src/Private/Get-AbrVbrCloudConnectTenant.ps1
@@ -6,7 +6,7 @@ function Get-AbrVbrCloudConnectTenant {
     .DESCRIPTION
         Documents the configuration of Veeam VBR in Word/HTML/Text formats using PScribo.
     .NOTES
-        Version:        0.8.0
+        Version:        0.8.1
         Author:         Jonathan Colon
         Twitter:        @jcolonfzenpr
         Github:         rebelinux

--- a/Src/Private/Get-AbrVbrCloudConnectTenant.ps1
+++ b/Src/Private/Get-AbrVbrCloudConnectTenant.ps1
@@ -26,7 +26,7 @@ function Get-AbrVbrCloudConnectTenant {
 
     process {
         try {
-            if (Get-VBRInstalledLicense | Where-Object {$_.CloudConnect -in @("Enterprise")}) {
+            if (Get-VBRInstalledLicense | Where-Object {$_.CloudConnect -ne "Disabled"}) {
                 $CloudObjects = Get-VBRCloudTenant | Sort-Object -Property Name
                 if ($CloudObjects) {
                     Section -Style Heading3 'Tenants' {

--- a/Src/Private/Get-AbrVbrCloudConnectTenant.ps1
+++ b/Src/Private/Get-AbrVbrCloudConnectTenant.ps1
@@ -6,7 +6,7 @@ function Get-AbrVbrCloudConnectTenant {
     .DESCRIPTION
         Documents the configuration of Veeam VBR in Word/HTML/Text formats using PScribo.
     .NOTES
-        Version:        0.8.1
+        Version:        0.8.3
         Author:         Jonathan Colon
         Twitter:        @jcolonfzenpr
         Github:         rebelinux

--- a/Src/Public/Invoke-AsBuiltReport.Veeam.VBR.ps1
+++ b/Src/Public/Invoke-AsBuiltReport.Veeam.VBR.ps1
@@ -5,7 +5,7 @@ function Invoke-AsBuiltReport.Veeam.VBR {
     .DESCRIPTION
         Documents the configuration of Veeam VBR in Word/HTML/Text formats using PScribo.
     .NOTES
-        Version:        0.8.3
+        Version:        0.8.4
         Author:         Jonathan Colon
         Twitter:        @jcolonfzenpr
         Github:         rebelinux

--- a/Src/Public/Invoke-AsBuiltReport.Veeam.VBR.ps1
+++ b/Src/Public/Invoke-AsBuiltReport.Veeam.VBR.ps1
@@ -5,7 +5,7 @@ function Invoke-AsBuiltReport.Veeam.VBR {
     .DESCRIPTION
         Documents the configuration of Veeam VBR in Word/HTML/Text formats using PScribo.
     .NOTES
-        Version:        0.8.4
+        Version:        0.8.3
         Author:         Jonathan Colon
         Twitter:        @jcolonfzenpr
         Github:         rebelinux


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Cloud Connect is currently identified using this logic ([link](https://github.com/AsBuiltReport/AsBuiltReport.Veeam.VBR/blob/dev/Src/Private/Get-AbrVbrCloudConnectTenant.ps1#L29)): 

`Get-VBRInstalledLicense | Where-Object {$_.CloudConnect -in @("Enterprise")}`

However, this logic does not work for service providers using Cloud Connect. Instead, the below logic should be used:

`Get-VBRInstalledLicense | Where-Object {$_.CloudConnect -ne "Disabled"}`

## Related Issue

Fixes #121 

## Motivation and Context

Current logic is unable to determine if Cloud Connect for Service Providers is being used. As such, all of the amazing Cloud Connect reporting is missing from the report.

## How Has This Been Tested?

Tested in two separate lab environments where a Cloud Connect server was being used with a service provider Cloud Connect license installed.

Each lab environment is unique and is configured and managed by different people. A lab environment consists of a functioning Cloud Connect environment.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
