### PR TITLE
v0.8.13

### DIFF
--- a/AsBuiltReport.Veeam.VBR.psd1
+++ b/AsBuiltReport.Veeam.VBR.psd1
@@ -67,7 +67,7 @@
         }
         @{
             ModuleName = 'Veeam.Diagrammer';
-            ModuleVersion = '0.6.17'
+            ModuleVersion = '0.6.18'
         }
     )
 

--- a/AsBuiltreport.Veeam.VBR.json
+++ b/AsBuiltreport.Veeam.VBR.json
@@ -48,7 +48,8 @@
         "Inventory": {
             "FileShare": 1,
             "PHY": 1,
-            "VI": 1
+            "VI": 1,
+            "EntraID": 1
         },
         "Storage": {
             "ISILON": 1,
@@ -71,6 +72,7 @@
             "Agent": 1,
             "Backup": 1,
             "BackupCopy": 1,
+            "EntraID": 3,
             "FileShare": 1,
             "Surebackup": 1,
             "Replication": 1,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.8.13] - Unreleased
 
+### Added
+
+- Add EntraID Tenant configuration
+  - Add Objects Backup Job information
+
 ### Changed
 
 - Increase Veeam.Diagrammer minimum requirement to v0.6.17

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fix error "A positional parameter cannot be found that accepts argument '-'" at Get-AbrVbrConfigurationBackupSetting cmdlet
+- Fix ConvertTo-HashToYN cmdlet not generating an ordereddictionary output
 
 ## [0.8.12] - 2024-11-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ##### This project is community maintained and has no sponsorship from Veeam, its employees or any of its affiliates.
 
-## [0.8.13] - Unreleased
+## [0.8.13] - 2024-12-11
 
 ### Added
 
@@ -17,10 +17,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Add Signature Detection
 - Update Security & Compliance Best Practice content
 - Add Syslog Event Filter information
+- Add Google Cloud Storage repository information
 
 ### Changed
 
-- Increase Veeam.Diagrammer minimum requirement to v0.6.17
+- Increase Veeam.Diagrammer minimum requirement to v0.6.18
 - Change the infrastructure diagram default save location to $OutputFolderPath
 - Increase AsBuiltReport.Core to v1.4.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add EntraID Tenant configuration
   - Add Objects Backup Job information
+- Update Malware detection setting
+  - Add Signature Detection
+- Update Security & Compliance Best Practice content
+- Add Syslog Event Filter information
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -212,6 +212,7 @@ The table below outlines the default and maximum **InfoLevel** settings for each
 | VI         |        1        |        1        |
 | PHY        |        1        |        2        |
 | FileShare  |        1        |        1        |
+| EntraID    |        1        |        1        |
 
 The table below outlines the default and maximum **InfoLevel** settings for each Storage Infrastructure section.
 
@@ -232,6 +233,7 @@ The table below outlines the default and maximum **InfoLevel** settings for each
 | FileShare   |        1        |        2        |
 | Replication |        1        |        2        |
 | Restores    |        0        |        1        |
+| EntraID     |        1        |        2        |
 
 The table below outlines the default and maximum **InfoLevel** settings for each Replication section.
 

--- a/Src/Private/Get-AbrVbrAgentBackupjobConf.ps1
+++ b/Src/Private/Get-AbrVbrAgentBackupjobConf.ps1
@@ -56,7 +56,7 @@ function Get-AbrVbrAgentBackupjobConf {
                                         $OutObj = [pscustomobject](ConvertTo-HashToYN $inObj)
 
                                         if ($HealthCheck.Jobs.BestPractice) {
-                                            $OutObj | Where-Object { $Null -like $_.'Description' } | Set-Style -Style Warning -Property 'Description'
+                                            $OutObj | Where-Object { $_.'Description' -eq "--" } | Set-Style -Style Warning -Property 'Description'
                                             $OutObj | Where-Object { $_.'Description' -match "Created by" } | Set-Style -Style Warning -Property 'Description'
                                         }
 
@@ -70,8 +70,7 @@ function Get-AbrVbrAgentBackupjobConf {
                                         }
                                         $OutObj | Table @TableParams
                                         if ($HealthCheck.Jobs.BestPractice) {
-                                            if ($OutObj | Where-Object { $_.'Description' -match 'Created by' -or $Null -like $_.'Description' }) {
-                                                Paragraph "Health Check:" -Bold -Underline
+                                            if ($OutObj | Where-Object { $_.'Description' -match 'Created by' -or $_.'Description' -eq '--' }) {                                                Paragraph "Health Check:" -Bold -Underline
                                                 BlankLine
                                                 Paragraph {
                                                     Text "Best Practice:" -Bold

--- a/Src/Private/Get-AbrVbrBackupRepository.ps1
+++ b/Src/Private/Get-AbrVbrBackupRepository.ps1
@@ -6,7 +6,7 @@ function Get-AbrVbrBackupRepository {
     .DESCRIPTION
         Documents the configuration of Veeam VBR in Word/HTML/Text formats using PScribo.
     .NOTES
-        Version:        0.8.12
+        Version:        0.8.13
         Author:         Jonathan Colon
         Twitter:        @jcolonfzenpr
         Github:         rebelinux
@@ -226,11 +226,22 @@ function Get-AbrVbrBackupRepository {
                                                     $inObj.Remove('Extent of ScaleOut Backup Repository')
                                                 }
 
-                                                if ($BackupRepo.Type -in @('AmazonS3Compatible', 'WasabiS3')) {
+                                                if ($BackupRepo.Type -in @('GoogleCloudStorage')) {
+                                                    $inObj.Add('Region Id', ($BackupRepos.GoogleCloudOptions.RegionId))
+                                                    $inObj.Add('Region Type', ( $BackupRepos.GoogleCloudOptions.RegionType))
+                                                    $inObj.Add('Bucket Name', ( $BackupRepos.GoogleCloudOptions.BucketName))
+                                                    $inObj.Add('Folder Name', ( $BackupRepos.GoogleCloudOptions.FolderName))
+                                                    $inObj.Add('Storage Class', ( $BackupRepos.GoogleCloudOptions.StorageClass))
+                                                    $inObj.Add('Enable Nearline Storage Class', ( $BackupRepos.GoogleCloudOptions.EnableNearlineStorageClass))
+                                                    $inObj.Add('Enable Coldline Storage Class', ( $BackupRepos.GoogleCloudOptions.EnableColdlineStorageClass))
+                                                    $inObj.Remove('Path')
+                                                }
+
+                                                if ($BackupRepo.Type -in @('AmazonS3Compatible', 'WasabiS3', 'GoogleCloudStorage')) {
                                                     $inObj.Add('Object Lock Enabled', ($BackupRepo.ObjectLockEnabled))
                                                 }
 
-                                                if ($BackupRepo.Type -in @('AmazonS3Compatible', 'WasabiS3')) {
+                                                if ($BackupRepo.Type -in @('AmazonS3Compatible', 'WasabiS3', 'GoogleCloudStorage')) {
                                                     $inObj.Add('Mount Server', (Get-VBRServer | Where-Object { $_.id -eq $BackupRepo.MountHostId.Guid }).Name)
                                                 }
 

--- a/Src/Private/Get-AbrVbrBackupServerInfo.ps1
+++ b/Src/Private/Get-AbrVbrBackupServerInfo.ps1
@@ -6,7 +6,7 @@ function Get-AbrVbrBackupServerInfo {
     .DESCRIPTION
         Documents the configuration of Veeam VBR in Word/HTML/Text formats using PScribo.
     .NOTES
-        Version:        0.8.12
+        Version:        0.8.13
         Author:         Jonathan Colon
         Twitter:        @jcolonfzenpr
         Github:         rebelinux
@@ -425,6 +425,12 @@ function Get-AbrVbrBackupServerInfo {
                                     "ProviderCredentialsId" = ""
                                     "ProviderInfo" = ""
                                     "ProviderId" = ""
+                                    "EntraIdSqlHostName" = "localhost"
+                                    "EntraIdSqlHostPort" = "5432"
+                                    "EntraIdSqlPassword" = ""
+                                    "EntraIdSqlServiceName" = "postgresql-x64-15"
+                                    "EntraIdSqlUserName" = "postgres"
+                                    "HighestDetectedVMCVersion" = ""
                                 }
                                 if ($VeeamInfo) {
                                     $OutObj = @()
@@ -444,7 +450,6 @@ function Get-AbrVbrBackupServerInfo {
                                                     0 { '--' }
                                                     1 { $Registry.Value }
                                                     default { $Registry.Value -Join ', ' }
-
                                                 }
                                             }
                                             $OutObj += [pscustomobject](ConvertTo-HashToYN $inObj)

--- a/Src/Private/Get-AbrVbrCloudConnectCG.ps1
+++ b/Src/Private/Get-AbrVbrCloudConnectCG.ps1
@@ -6,7 +6,7 @@ function Get-AbrVbrCloudConnectCG {
     .DESCRIPTION
         Documents the configuration of Veeam VBR in Word/HTML/Text formats using PScribo.
     .NOTES
-        Version:        0.8.12
+        Version:        0.8.13
         Author:         Jonathan Colon
         Twitter:        @jcolonfzenpr
         Github:         rebelinux
@@ -66,7 +66,7 @@ function Get-AbrVbrCloudConnectCG {
 
                                         $OutObj = [pscustomobject](ConvertTo-HashToYN $inObj)
                                         if ($HealthCheck.Jobs.BestPractice) {
-                                            $OutObj | Where-Object { $Null -like $_.'Description' } | Set-Style -Style Warning -Property 'Description'
+                                            $OutObj | Where-Object { $_.'Description' -eq "--" } | Set-Style -Style Warning -Property 'Description'
                                             $OutObj | Where-Object { $_.'Description' -match "Created by" } | Set-Style -Style Warning -Property 'Description'
                                         }
 
@@ -81,8 +81,7 @@ function Get-AbrVbrCloudConnectCG {
                                         }
                                         $OutObj | Sort-Object -Property 'Name' | Table @TableParams
                                         if ($HealthCheck.Jobs.BestPractice) {
-                                            if ($OutObj | Where-Object { $_.'Description' -match 'Created by' -or $Null -like $_.'Description' }) {
-                                                Paragraph "Health Check:" -Bold -Underline
+                                            if ($OutObj | Where-Object { $_.'Description' -match 'Created by' -or $_.'Description' -eq '--' }) {                                                Paragraph "Health Check:" -Bold -Underline
                                                 BlankLine
                                                 Paragraph {
                                                     Text "Best Practice:" -Bold

--- a/Src/Private/Get-AbrVbrCloudConnectGP.ps1
+++ b/Src/Private/Get-AbrVbrCloudConnectGP.ps1
@@ -6,7 +6,7 @@ function Get-AbrVbrCloudConnectGP {
     .DESCRIPTION
         Documents the configuration of Veeam VBR in Word/HTML/Text formats using PScribo.
     .NOTES
-        Version:        0.8.12
+        Version:        0.8.13
         Author:         Jonathan Colon
         Twitter:        @jcolonfzenpr
         Github:         rebelinux
@@ -50,7 +50,7 @@ function Get-AbrVbrCloudConnectGP {
                             }
 
                             if ($HealthCheck.Jobs.BestPractice) {
-                                $OutObj | Where-Object { $Null -like $_.'Description' } | Set-Style -Style Warning -Property 'Description'
+                                $OutObj | Where-Object { $_.'Description' -eq "--" } | Set-Style -Style Warning -Property 'Description'
                                 $OutObj | Where-Object { $_.'Description' -match "Created by" } | Set-Style -Style Warning -Property 'Description'
                             }
 
@@ -65,8 +65,7 @@ function Get-AbrVbrCloudConnectGP {
                             }
                             $OutObj | Sort-Object -Property 'Name' | Table @TableParams
                             if ($HealthCheck.Jobs.BestPractice) {
-                                if ($OutObj | Where-Object { $_.'Description' -match 'Created by' -or $Null -like $_.'Description' }) {
-                                    Paragraph "Health Check:" -Bold -Underline
+                                if ($OutObj | Where-Object { $_.'Description' -match 'Created by' -or $_.'Description' -eq '--' }) {                                    Paragraph "Health Check:" -Bold -Underline
                                     BlankLine
                                     Paragraph {
                                         Text "Best Practice:" -Bold

--- a/Src/Private/Get-AbrVbrCloudConnectTenant.ps1
+++ b/Src/Private/Get-AbrVbrCloudConnectTenant.ps1
@@ -6,7 +6,7 @@ function Get-AbrVbrCloudConnectTenant {
     .DESCRIPTION
         Documents the configuration of Veeam VBR in Word/HTML/Text formats using PScribo.
     .NOTES
-        Version:        0.8.12
+        Version:        0.8.13
         Author:         Jonathan Colon
         Twitter:        @jcolonfzenpr
         Github:         rebelinux
@@ -134,7 +134,7 @@ function Get-AbrVbrCloudConnectTenant {
                                                     $OutObj = [pscustomobject](ConvertTo-HashToYN $inObj)
 
                                                     if ($HealthCheck.CloudConnect.BestPractice) {
-                                                        $OutObj | Where-Object { $Null -like $_.'Description' } | Set-Style -Style Warning -Property 'Description'
+                                                        $OutObj | Where-Object { $_.'Description' -eq "--" } | Set-Style -Style Warning -Property 'Description'
                                                         $OutObj | Where-Object { $_.'Description' -match "Created by" } | Set-Style -Style Warning -Property 'Description'
                                                         $OutObj | Where-Object { $_.'Expiration Date' -match '(Expired)' } | Set-Style -Style Warning -Property 'Expiration Date'
                                                     }
@@ -150,8 +150,7 @@ function Get-AbrVbrCloudConnectTenant {
                                                     }
                                                     $OutObj | Sort-Object -Property 'Name' | Table @TableParams
                                                     if ($HealthCheck.Jobs.BestPractice) {
-                                                        if ($OutObj | Where-Object { $_.'Description' -match 'Created by' -or $Null -like $_.'Description' }) {
-                                                            Paragraph "Health Check:" -Bold -Underline
+                                                        if ($OutObj | Where-Object { $_.'Description' -match 'Created by' -or $_.'Description' -eq '--' }) {                                                            Paragraph "Health Check:" -Bold -Underline
                                                             BlankLine
                                                             Paragraph {
                                                                 Text "Best Practice:" -Bold

--- a/Src/Private/Get-AbrVbrEntraIDBackupjob.ps1
+++ b/Src/Private/Get-AbrVbrEntraIDBackupjob.ps1
@@ -1,0 +1,67 @@
+
+function Get-AbrVbrEntraIDBackupjob {
+    <#
+    .SYNOPSIS
+        Used by As Built Report to returns entraid jobs created in Veeam Backup & Replication.
+    .DESCRIPTION
+        Documents the configuration of Veeam VBR in Word/HTML/Text formats using PScribo.
+    .NOTES
+        Version:        0.8.13
+        Author:         Jonathan Colon
+        Twitter:        @jcolonfzenpr
+        Github:         rebelinux
+        Credits:        Iain Brighton (@iainbrighton) - PScribo module
+
+    .LINK
+        https://github.com/AsBuiltReport/AsBuiltReport.Veeam.VBR
+    #>
+    [CmdletBinding()]
+    param (
+
+    )
+
+    begin {
+        Write-PScriboMessage "Discovering Veeam VBR EntraID Tenant Backup jobs information from $System."
+    }
+
+    process {
+        try {
+            if ($Bkjobs = Get-VBREntraIDTenantBackupJob | Sort-Object -Property 'Name') {
+                Section -Style Heading3 'EntraID Tenant Backup Jobs' {
+                    Paragraph "The following section list entraid tenant jobs created in Veeam Backup & Replication."
+                    BlankLine
+                    $OutObj = @()
+                    foreach ($Bkjob in $Bkjobs) {
+                        try {
+                            Write-PScriboMessage "Discovered $($Bkjob.Name) Backup Job."
+                            $inObj = [ordered] @{
+                                'Name' = $Bkjob.Name
+                                'Tenant' = $Bkjob.Tenant.Name
+                                'Schedule Status' = Switch ($Bkjob.EnableSchedule) {
+                                    'False' { 'Not Scheduled' }
+                                    'True' { 'Scheduled' }
+                                }
+                            }
+                            $OutObj += [pscustomobject](ConvertTo-HashToYN $inObj)
+                        } catch {
+                            Write-PScriboMessage -IsWarning "EntraID Tenant Backup Jobs $($SBkjob.Name) Section: $($_.Exception.Message)"
+                        }
+                    }
+
+                    $TableParams = @{
+                        Name = "EntraID Tenant Backup Jobs - $VeeamBackupServer"
+                        List = $false
+                        ColumnWidths = 40, 40, 20
+                    }
+                    if ($Report.ShowTableCaptions) {
+                        $TableParams['Caption'] = "- $($TableParams.Name)"
+                    }
+                    $OutObj | Sort-Object -Property 'Tenant' | Table @TableParams
+                }
+            }
+        } catch {
+            Write-PScriboMessage -IsWarning "EntraID Tenant Backup Jobs Section: $($_.Exception.Message)"
+        }
+    }
+    end {}
+}

--- a/Src/Private/Get-AbrVbrEntraIDBackupjobConf.ps1
+++ b/Src/Private/Get-AbrVbrEntraIDBackupjobConf.ps1
@@ -1,0 +1,326 @@
+
+function Get-AbrVbrEntraIDBackupjobConf {
+    <#
+    .SYNOPSIS
+        Used by As Built Report to returns entraid jobs created in Veeam Backup & Replication.
+    .DESCRIPTION
+        Documents the configuration of Veeam VBR in Word/HTML/Text formats using PScribo.
+    .NOTES
+        Version:        0.8.13
+        Author:         Jonathan Colon
+        Twitter:        @jcolonfzenpr
+        Github:         rebelinux
+        Credits:        Iain Brighton (@iainbrighton) - PScribo module
+
+    .LINK
+        https://github.com/AsBuiltReport/AsBuiltReport.Veeam.VBR
+    #>
+    [CmdletBinding()]
+    param (
+
+    )
+
+    begin {
+        Write-PScriboMessage "Discovering Veeam VBR EntraID Tenant Backup jobs information from $System."
+    }
+
+    process {
+        try {
+            if ($Bkjobs = Get-VBREntraIDTenantBackupJob | Sort-Object -Property 'Name') {
+                Section -Style Heading3 'EntraID Tenant Backup Jobs Configuration' {
+                    Paragraph "The following section details the configuration of backup copy jobs."
+                    BlankLine
+                    $OutObj = @()
+                    foreach ($Bkjob in $Bkjobs) {
+                        try {
+                            Section -Style Heading4 $($Bkjob.Name) {
+                                Section -Style NOTOCHeading4 -ExcludeFromTOC 'Common Information' {
+                                    $OutObj = @()
+                                    try {
+                                        try {
+                                            Write-PScriboMessage "Discovered $($Bkjob.Name) common information."
+                                            $inObj = [ordered] @{
+                                                'Name' = $Bkjob.Name
+                                                'Id' = $Bkjob.Id
+                                                'Next Run' = $Bkjob.ScheduleOptions.NextRun
+                                                'Description' = $Bkjob.Description
+                                            }
+                                            $OutObj = [pscustomobject](ConvertTo-HashToYN $inObj)
+                                        } catch {
+                                            Write-PScriboMessage -IsWarning $_.Exception.Message
+                                        }
+
+                                        if ($HealthCheck.Jobs.BestPractice) {
+                                            $OutObj | Where-Object { $Null -like $_.'Description' -or $_.'Description' -eq "--" } | Set-Style -Style Warning -Property 'Description'
+                                            $OutObj | Where-Object { $_.'Description' -match "Created by" } | Set-Style -Style Warning -Property 'Description'
+                                        }
+
+                                        $TableParams = @{
+                                            Name = "Common Information - $($Bkjob.Name)"
+                                            List = $true
+                                            ColumnWidths = 40, 60
+                                        }
+                                        if ($Report.ShowTableCaptions) {
+                                            $TableParams['Caption'] = "- $($TableParams.Name)"
+                                        }
+                                        $OutObj | Table @TableParams
+                                        if ($HealthCheck.Jobs.BestPractice) {
+                                            if ($OutObj | Where-Object { $_.'Description' -match 'Created by' -or $_.'Description' -eq '--' }) {
+                                                Paragraph "Health Check:" -Bold -Underline
+                                                BlankLine
+                                                Paragraph {
+                                                    Text "Best Practice:" -Bold
+                                                    Text "It is a general rule of good practice to establish well-defined descriptions. This helps to speed up the fault identification process, as well as enabling better documentation of the environment."
+                                                }
+                                                BlankLine
+                                            }
+                                        }
+                                    } catch {
+                                        Write-PScriboMessage -IsWarning $_.Exception.Message
+                                    }
+                                }
+                                Section -Style NOTOCHeading4 -ExcludeFromTOC 'Tenant' {
+                                    $OutObj = @()
+                                    try {
+                                        Write-PScriboMessage "Discovered $($Bkjob.Tenant.Name) EntraID Tenant."
+                                        $inObj = [ordered] @{
+                                            'Name' = $Bkjob.Tenant.Name
+                                            'Azure Tenant Id' = $Bkjob.Tenant.AzureTenantId
+                                            'Application Id' = $Bkjob.Tenant.ApplicationId
+                                            'Region' = $Bkjob.Tenant.Region
+                                            'Cache Repository' = $Bkjob.Tenant.CacheRepository.Name
+                                            'Retention Policy' = "$($Bkjob.RetentionPolicy) days"
+                                            'Description' = $Bkjob.Tenant.Description
+                                        }
+
+                                        $OutObj += [pscustomobject](ConvertTo-HashToYN $inObj)
+                                    } catch {
+                                        Write-PScriboMessage -IsWarning "Entra ID Tenant Section: $($_.Exception.Message)"
+                                    }
+
+                                    if ($HealthCheck.Jobs.BestPractice) {
+                                        $OutObj | Where-Object { $_.'Description' -eq "--" } | Set-Style -Style Warning -Property 'Description'
+                                        $OutObj | Where-Object { $_.'Description' -match "Created by" } | Set-Style -Style Warning -Property 'Description'
+                                    }
+
+                                    $TableParams = @{
+                                        Name = "Tenant Information - $($Bkjob.Name)"
+                                        List = $True
+                                        ColumnWidths = 40, 60
+                                    }
+
+                                    if ($Report.ShowTableCaptions) {
+                                        $TableParams['Caption'] = "- $($TableParams.Name)"
+                                    }
+                                    $OutObj | Sort-Object -Property 'Name' | Table @TableParams
+                                    if ($HealthCheck.Jobs.BestPractice) {
+                                        if ($OutObj | Where-Object { $_.'Description' -match 'Created by' -or $_.'Description' -eq '--' }) {
+                                            Paragraph "Health Check:" -Bold -Underline
+                                            BlankLine
+                                            Paragraph {
+                                                Text "Best Practice:" -Bold
+                                                Text "It is a general rule of good practice to establish well-defined descriptions. This helps to speed up the fault identification process, as well as enabling better documentation of the environment."
+                                            }
+                                            BlankLine
+                                        }
+                                    }
+                                    if ($InfoLevel.Jobs.EntraID -ge 2) {
+                                        Section -Style NOTOCHeading5 -ExcludeFromTOC 'Advanced Settings (Encryption)' {
+                                            $OutObj = @()
+                                            try {
+                                                Write-PScriboMessage "Discovered $($Bkjob.Tenant.Name) EntraID Encryption."
+                                                $inObj = [ordered] @{
+                                                    'Enabled' = $Bkjob.EncryptionOptions.Enabled
+                                                    'Id' = $Bkjob.EncryptionOptions.key.Id
+                                                    'Last Modified Date' = $Bkjob.EncryptionOptions.key.LastModifiedDate
+                                                    'Description' = $Bkjob.EncryptionOptions.key.Description
+                                                }
+
+                                                $OutObj += [pscustomobject](ConvertTo-HashToYN $inObj)
+                                            } catch {
+                                                Write-PScriboMessage -IsWarning "Entra ID Encryption Section: $($_.Exception.Message)"
+                                            }
+
+                                            if ($HealthCheck.Jobs.BestPractice) {
+                                                $OutObj | Where-Object { $_.'Enabled' -eq "No" } | Set-Style -Style Warning -Property 'Enabled'
+                                            }
+
+                                            $TableParams = @{
+                                                Name = "Encryption - $($Bkjob.Name)"
+                                                List = $True
+                                                ColumnWidths = 40, 60
+                                            }
+
+                                            if ($Report.ShowTableCaptions) {
+                                                $TableParams['Caption'] = "- $($TableParams.Name)"
+                                            }
+                                            $OutObj | Table @TableParams
+                                            if ($HealthCheck.Jobs.BestPractice) {
+                                                if ($OutObj | Where-Object { $_.'Enabled Backup File Encryption' -eq 'No' }) {
+                                                    Paragraph "Health Check:" -Bold -Underline
+                                                    BlankLine
+                                                    Paragraph {
+                                                        Text "Best Practice:" -Bold
+                                                        Text "Backup and replica data is a high potential source of vulnerability. To secure data stored in backups and replicas, use Veeam Backup & Replication inbuilt encryption to protect data in backups"
+                                                    }
+                                                    BlankLine
+                                                }
+                                            }
+                                        }
+                                    }
+                                    if ($InfoLevel.Jobs.EntraID -ge 2) {
+                                        Section -Style NOTOCHeading5 -ExcludeFromTOC "Advanced Settings (Notification)" {
+                                            $OutObj = @()
+                                            try {
+                                                Write-PScriboMessage "Discovered $($Bkjob.Name) notification options."
+                                                $inObj = [ordered] @{
+                                                    'Send Snmp Notification' = $Bkjob.NotificationOptions.EnableSnmpNotification
+                                                    'Send Email Notification' = $Bkjob.NotificationOptions.EnableAdditionalNotification
+                                                    'Email Notification Additional Addresses' = Switch ($Bkjob.NotificationOptions.AdditionalAddress) {
+                                                        $Null { '--' }
+                                                        default { $Bkjob.NotificationOptions.AdditionalAddress }
+                                                    }
+                                                    'Email Notify Time' = $Bkjob.NotificationOptions.SendTime
+                                                    'Use Custom Email Notification Options' = $Bkjob.NotificationOptions.UseNotificationOptions
+                                                    'Use Custom Notification Setting' = $Bkjob.NotificationOptions.NotificationSubject
+                                                    'Notify On Success' = $Bkjob.NotificationOptions.NotifyOnSuccess
+                                                    'Notify On Warning' = $Bkjob.NotificationOptions.NotifyOnWarning
+                                                    'Notify On Error' = $Bkjob.NotificationOptions.NotifyOnError
+                                                    'Send notification' = Switch ($Bkjob.NotificationOptions.EnableDailyNotification) {
+                                                        'False' { 'Immediately after each copied backup' }
+                                                        'True' { 'Daily as a summary' }
+                                                        default { 'Unknown' }
+                                                    }
+                                                }
+                                                $OutObj = [pscustomobject](ConvertTo-HashToYN $inObj)
+
+                                                $TableParams = @{
+                                                    Name = "Notification - $($Bkjob.Name)"
+                                                    List = $true
+                                                    ColumnWidths = 40, 60
+                                                }
+                                                if ($Report.ShowTableCaptions) {
+                                                    $TableParams['Caption'] = "- $($TableParams.Name)"
+                                                }
+                                                $OutObj | Table @TableParams
+                                            } catch {
+                                                Write-PScriboMessage -IsWarning $_.Exception.Message
+                                            }
+                                        }
+                                    }
+                                    if ($Bkjob.EnableSchedule) {
+                                        Section -Style NOTOCHeading5 -ExcludeFromTOC "Schedule" {
+                                            $OutObj = @()
+                                            try {
+                                                Write-PScriboMessage "Discovered $($Bkjob.Name) schedule options."
+                                                if ($Bkjob.ScheduleOptions.OptionsDaily.Enabled -eq "True") {
+                                                    $ScheduleType = "Daily"
+                                                    $Schedule = "Kind: $($Bkjob.ScheduleOptions.OptionsDaily.Kind),`r`nDays: $($Bkjob.ScheduleOptions.OptionsDaily.DaysSrv)"
+                                                } elseif ($Bkjob.ScheduleOptions.OptionsMonthly.Enabled -eq "True") {
+                                                    $ScheduleType = "Monthly"
+                                                    $Schedule = "Day Of Month: $($Bkjob.ScheduleOptions.OptionsMonthly.DayOfMonth),`r`nDay Number In Month: $($Bkjob.ScheduleOptions.OptionsMonthly.DayNumberInMonth),`r`nDay Of Week: $($Bkjob.ScheduleOptions.OptionsMonthly.DayOfWeek)"
+                                                } elseif ($Bkjob.ScheduleOptions.OptionsPeriodically.Enabled -eq "True") {
+                                                    $ScheduleType = $Bkjob.ScheduleOptions.OptionsPeriodically.Kind
+                                                    $Schedule = "Full Period: $($Bkjob.ScheduleOptions.OptionsPeriodically.FullPeriod),`r`nHourly Offset: $($Bkjob.ScheduleOptions.OptionsPeriodically.HourlyOffset),`r`nUnit: $($Bkjob.ScheduleOptions.OptionsPeriodically.Unit)"
+                                                } elseif ($Bkjob.ScheduleOptions.OptionsContinuous.Enabled -eq "True") {
+                                                    $ScheduleType = 'Continuous'
+                                                    $Schedule = "Schedule Time Period"
+                                                } elseif ($Bkjob.ScheduleOptions.OptionsScheduleAfterJob.IsEnabled) {
+                                                    $ScheduleType = 'After Job'
+                                                }
+                                                $inObj = [ordered] @{
+                                                    'Retry Failed item' = $Bkjob.ScheduleOptions.RetryTimes
+                                                    'Wait before each retry' = "$($Bkjob.ScheduleOptions.RetryTimeout)/min"
+                                                    'Backup Window' = $Bkjob.ScheduleOptions.OptionsBackupWindow.IsEnabled
+                                                    'Shedule type' = $ScheduleType
+                                                    'Shedule Options' = $Schedule
+                                                    'Start Time' = $Bkjob.ScheduleOptions.OptionsDaily.TimeLocal.ToShorttimeString()
+                                                    'Latest Run' = $Bkjob.ScheduleOptions.LatestRunLocal
+                                                }
+                                                $OutObj = [pscustomobject](ConvertTo-HashToYN $inObj)
+
+                                                $TableParams = @{
+                                                    Name = "Schedule Options - $($Bkjob.Name)"
+                                                    List = $true
+                                                    ColumnWidths = 40, 60
+                                                }
+                                                if ($Report.ShowTableCaptions) {
+                                                    $TableParams['Caption'] = "- $($TableParams.Name)"
+                                                }
+                                                $OutObj | Table @TableParams
+                                                if ($Bkjob.ScheduleOptions.OptionsBackupWindow.IsEnabled -or $Bkjob.ScheduleOptions.OptionsContinuous.Enabled) {
+                                                    Section -Style NOTOCHeading6 -ExcludeFromTOC "Backup Window Time Period" {
+                                                        Paragraph -ScriptBlock $Legend
+
+                                                        $OutObj = @()
+                                                        try {
+                                                            $ScheduleTimePeriod = @()
+                                                            $Days = 'Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'
+                                                            foreach ($Day in $Days) {
+
+                                                                $Regex = [Regex]::new("(?<=<$Day>)(.*)(?=</$Day>)")
+                                                                if ($Bkjob.ScheduleOptions.OptionsPeriodically.Enabled) {
+                                                                    $BackupWindow = $Bkjob.ScheduleOptions.OptionsPeriodically.Schedule
+                                                                } elseif ($Bkjob.ScheduleOptions.OptionsContinuous.Enabled) {
+                                                                    $BackupWindow = $Bkjob.ScheduleOptions.OptionsContinuous.Schedule
+                                                                } else { $BackupWindow = $Bkjob.ScheduleOptions.OptionsBackupWindow.BackupWindow }
+                                                                $Match = $Regex.Match($BackupWindow)
+                                                                if ($Match.Success) {
+                                                                    $ScheduleTimePeriod += $Match.Value
+                                                                }
+                                                            }
+
+                                                            $OutObj = Get-WindowsTimePeriod -InputTimePeriod $ScheduleTimePeriod
+
+                                                            $TableParams = @{
+                                                                Name = "Backup Window - $($Bkjob.Name)"
+                                                                List = $true
+                                                                ColumnWidths = 6, 4, 3, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 3, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4
+                                                                Key = 'H'
+                                                            }
+                                                            if ($Report.ShowTableCaptions) {
+                                                                $TableParams['Caption'] = "- $($TableParams.Name)"
+                                                            }
+                                                            if ($OutObj) {
+                                                                $OutObj2 = Table -Hashtable $OutObj @TableParams
+                                                                $OutObj2.Rows | Where-Object { $_.Sun -eq "0" } | Set-Style -Style ON -Property "Sun"
+                                                                $OutObj2.Rows | Where-Object { $_.Mon -eq "0" } | Set-Style -Style ON -Property "Mon"
+                                                                $OutObj2.Rows | Where-Object { $_.Tue -eq "0" } | Set-Style -Style ON -Property "Tue"
+                                                                $OutObj2.Rows | Where-Object { $_.Wed -eq "0" } | Set-Style -Style ON -Property "Wed"
+                                                                $OutObj2.Rows | Where-Object { $_.Thu -eq "0" } | Set-Style -Style ON -Property "Thu"
+                                                                $OutObj2.Rows | Where-Object { $_.Fri -eq "0" } | Set-Style -Style ON -Property "Fri"
+                                                                $OutObj2.Rows | Where-Object { $_.Sat -eq "0" } | Set-Style -Style ON -Property "Sat"
+
+                                                                $OutObj2.Rows | Where-Object { $_.Sun -eq "1" } | Set-Style -Style OFF -Property "Sun"
+                                                                $OutObj2.Rows | Where-Object { $_.Mon -eq "1" } | Set-Style -Style OFF -Property "Mon"
+                                                                $OutObj2.Rows | Where-Object { $_.Tue -eq "1" } | Set-Style -Style OFF -Property "Tue"
+                                                                $OutObj2.Rows | Where-Object { $_.Wed -eq "1" } | Set-Style -Style OFF -Property "Wed"
+                                                                $OutObj2.Rows | Where-Object { $_.Thu -eq "1" } | Set-Style -Style OFF -Property "Thu"
+                                                                $OutObj2.Rows | Where-Object { $_.Fri -eq "1" } | Set-Style -Style OFF -Property "Fri"
+                                                                $OutObj2.Rows | Where-Object { $_.Sat -eq "1" } | Set-Style -Style OFF -Property "Sat"
+                                                                $OutObj2
+                                                            }
+                                                        } catch {
+                                                            Write-PScriboMessage -IsWarning "Entra ID Backup Jobs $($Bkjob.Name) Backup Windows Section: $($_.Exception.Message)"
+                                                        }
+                                                    }
+                                                }
+                                            } catch {
+                                                Write-PScriboMessage -IsWarning "Entra ID Backup Jobs $($Bkjob.Name) Schedule Section: $($_.Exception.Message)"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        } catch {
+                            Write-PScriboMessage -IsWarning $_.Exception.Message
+                        }
+                    }
+                }
+            }
+        } catch {
+            Write-PScriboMessage -IsWarning "EntraID Tenant Backup Jobs Section: $($_.Exception.Message)"
+        }
+    }
+    end {}
+}

--- a/Src/Private/Get-AbrVbrEntraIDTenant.ps1
+++ b/Src/Private/Get-AbrVbrEntraIDTenant.ps1
@@ -1,0 +1,85 @@
+
+function Get-AbrVbrEntraIDTenant {
+    <#
+    .SYNOPSIS
+    Used by As Built Report to retrieve Veeam EntraID Information
+    .DESCRIPTION
+        Documents the configuration of Veeam VBR in Word/HTML/Text formats using PScribo.
+    .NOTES
+        Version:        0.8.13
+        Author:         Jonathan Colon
+        Twitter:        @jcolonfzenpr
+        Github:         rebelinux
+        Credits:        Iain Brighton (@iainbrighton) - PScribo module
+
+    .LINK
+        https://github.com/AsBuiltReport/AsBuiltReport.Veeam.VBR
+    #>
+    [CmdletBinding()]
+    param (
+
+    )
+
+    begin {
+        Write-PScriboMessage "Discovering Veeam VBR EntraID information from $System."
+    }
+
+    process {
+        if ($EntraIDObjs = Get-VBREntraIDTenant) {
+            Section -Style Heading3 'Entra ID Tenant' {
+                Paragraph "The following table provides a summary about the EntraID information from Veeam Server $VeeamBackupServer."
+                BlankLine
+                $OutObj = @()
+                try {
+                    foreach ($EntraIDObj in $EntraIDObjs) {
+                        try {
+                            Write-PScriboMessage "Discovered $($EntraIDObj.Name) EntraID Tenant."
+                            $inObj = [ordered] @{
+                                'Name' = $EntraIDObj.Name
+                                'Azure Tenant Id' = $EntraIDObj.AzureTenantId
+                                'Application Id' = $EntraIDObj.ApplicationId
+                                'Region' = $EntraIDObj.Region
+                                'Cache Repository' = $EntraIDObj.CacheRepository.Name
+                                'Description' = $EntraIDObj.Description
+                            }
+
+                            $OutObj += [pscustomobject](ConvertTo-HashToYN $inObj)
+                        } catch {
+                            Write-PScriboMessage -IsWarning "Entra ID Tenant Section: $($_.Exception.Message)"
+                        }
+
+                        if ($HealthCheck.Infrastructure.BestPractice) {
+                            $OutObj | Where-Object { $_.'Description' -eq "--" } | Set-Style -Style Warning -Property 'Description'
+                            $OutObj | Where-Object { $_.'Description' -match "Created by" } | Set-Style -Style Warning -Property 'Description'
+                        }
+
+                        $TableParams = @{
+                            Name = "$($EntraIDObj.Name) - $VeeamBackupServer"
+                            List = $True
+                            ColumnWidths = 40, 60
+                        }
+
+                        if ($Report.ShowTableCaptions) {
+                            $TableParams['Caption'] = "- $($TableParams.Name)"
+                        }
+                        $OutObj | Sort-Object -Property 'Name' | Table @TableParams
+                        if ($HealthCheck.Infrastructure.BestPractice) {
+                            if ($OutObj | Where-Object { $_.'Description' -match 'Created by' -or $_.'Description' -eq '--' }) {                                                Paragraph "Health Check:" -Bold -Underline
+                                BlankLine
+                                Paragraph {
+                                    Text "Best Practice:" -Bold
+                                    Text "It is a general rule of good practice to establish well-defined descriptions. This helps to speed up the fault identification process, as well as enabling better documentation of the environment."
+                                }
+                                BlankLine
+                            }
+                        }
+                    }
+                } catch {
+                    Write-PScriboMessage -IsWarning "Entra ID Tenant Section: $($_.Exception.Message)"
+                }
+            }
+        }
+    }
+    end {}
+
+}

--- a/Src/Private/Get-AbrVbrEventForwarding.ps1
+++ b/Src/Private/Get-AbrVbrEventForwarding.ps1
@@ -5,7 +5,7 @@ function Get-AbrVbrEventForwarding {
     .DESCRIPTION
         Documents the configuration of Veeam VBR in Word/HTML/Text formats using PScribo.
     .NOTES
-        Version:        0.8.12
+        Version:        0.8.13
         Author:         Jonathan Colon
         Twitter:        @jcolonfzenpr
         Github:         rebelinux

--- a/Src/Private/Get-AbrVbrEventForwarding.ps1
+++ b/Src/Private/Get-AbrVbrEventForwarding.ps1
@@ -66,6 +66,44 @@ function Get-AbrVbrEventForwarding {
                     }
                     BlankLine
                 }
+                try {
+                    $SyslogEventFilters = try { Get-VBRSyslogEventFilters } catch { Write-PScriboMessage "No syslog event filter configured" }
+                    Section -Style Heading4 'Syslog Event Filter' {
+                        $OutObj = @()
+                        foreach ($SyslogEventFilter in $SyslogEventFilters) {
+
+                            $SyslogEventFilterLevel = @()
+
+                            if ($SyslogEventFilter.FilterInfos) {
+                                $SyslogEventFilterLevel += 'Information'
+                            }
+                            if ($SyslogEventFilter.FilterWarnings) {
+                                $SyslogEventFilterLevel += 'Warning'
+                            }
+                            if ($SyslogEventFilter.FilterErrors) {
+                                $SyslogEventFilterLevel += 'Error'
+                            }
+
+                            $inObj = [ordered] @{
+                                'EventId' = $SyslogEventFilter.EventId
+                                'Level' = $SyslogEventFilterLevel -join ", "
+                            }
+                            $OutObj += [pscustomobject](ConvertTo-HashToYN $inObj)
+                        }
+
+                        $TableParams = @{
+                            Name = "Syslog Event Filter - $VeeamBackupServer"
+                            List = $false
+                            ColumnWidths = 50, 50
+                        }
+                        if ($Report.ShowTableCaptions) {
+                            $TableParams['Caption'] = "- $($TableParams.Name)"
+                        }
+                        $OutObj | Table @TableParams
+                    }
+                } catch {
+                    Write-PScriboMessage -IsWarning "Syslog Event Filter Section: $($_.Exception.Message)"
+                }
             }
         } catch {
             Write-PScriboMessage -IsWarning "Event Forwarding Section: $($_.Exception.Message)"

--- a/Src/Private/Get-AbrVbrFileSharesInfo.ps1
+++ b/Src/Private/Get-AbrVbrFileSharesInfo.ps1
@@ -6,7 +6,7 @@ function Get-AbrVbrFileSharesInfo {
     .DESCRIPTION
         Documents the configuration of Veeam VBR in Word/HTML/Text formats using PScribo.
     .NOTES
-        Version:        0.8.12
+        Version:        0.8.13
         Author:         Jonathan Colon
         Twitter:        @jcolonfzenpr
         Github:         rebelinux
@@ -27,7 +27,7 @@ function Get-AbrVbrFileSharesInfo {
     process {
         if ($ShareObjs = Get-VBRNASServer -WarningAction SilentlyContinue) {
             Section -Style Heading3 'File Shares' {
-                Paragraph "The following table provides a summary about the file shares backed-up by Veeam Server $(((Get-VBRServerSession).Server))."
+                Paragraph "The following table provides a summary about the file shares backed-up by Veeam Server $VeeamBackupServer."
                 BlankLine
                 $OutObj = @()
                 try {

--- a/Src/Private/Get-AbrVbrMalwareDetectionOption.ps1
+++ b/Src/Private/Get-AbrVbrMalwareDetectionOption.ps1
@@ -5,7 +5,7 @@ function Get-AbrVbrMalwareDetectionOption {
     .DESCRIPTION
         Documents the configuration of Veeam VBR in Word/HTML/Text formats using PScribo.
     .NOTES
-        Version:        0.8.12
+        Version:        0.8.13
         Author:         Jonathan Colon
         Twitter:        @jcolonfzenpr
         Github:         rebelinux
@@ -33,6 +33,12 @@ function Get-AbrVbrMalwareDetectionOption {
                     'Sensitivity' = $MalwareDetectionOption.Sensitivity
                     'File system activity analisys' = $MalwareDetectionOption.GuestIndexScanEnabled
                     'Update malware definition automatically' = $MalwareDetectionOption.UpdateExtensionsListPeriodically
+                    'Indicators Of Compromise Enabled' = $MalwareDetectionOption.UseIndicatorsOfCompromiseEnabled
+                    'Signature Detection' = Switch ($MalwareDetectionOption.DetectionEngine) {
+                        'VeeamThreatHunter' {'Veeam Threat Hunter'}
+                        'External' {'Bring your own antivirus'}
+                    }
+                    'Signature Detection - Scan Archives' = $MalwareDetectionOption.ScanArchives
                     'File Mask: Suspicious Extensions' = $MalwareDetectionOption.SuspiciousExtensions -join ","
                     'File Mask: Non Suspicious Extensions' = $MalwareDetectionOption.NonSuspiciousExtensions -join ","
                     'Incident API: Quick Backup On External Event' = $MalwareDetectionOption.QuickBackupOnExternalEventEnabled

--- a/Src/Private/Get-AbrVbrObjectRepository.ps1
+++ b/Src/Private/Get-AbrVbrObjectRepository.ps1
@@ -6,7 +6,7 @@ function Get-AbrVbrObjectRepository {
     .DESCRIPTION
         Documents the configuration of Veeam VBR in Word/HTML/Text formats using PScribo.
     .NOTES
-        Version:        0.8.12
+        Version:        0.8.13
         Author:         Jonathan Colon
         Twitter:        @jcolonfzenpr
         Github:         rebelinux
@@ -130,8 +130,16 @@ function Get-AbrVbrObjectRepository {
                                                     $inObj.remove('Service Point')
                                                     $inObj.remove('Amazon S3 Folder')
                                                     $inObj.remove('Immutability Period')
+                                                    $inObj.remove('Immutability Enabled	')
                                                     $inObj.add('Azure Blob Name', ($ObjectRepo.AzureBlobFolder).Name)
                                                     $inObj.add('Azure Blob Container', ($ObjectRepo.AzureBlobFolder).Container)
+                                                } elseif (($ObjectRepo).Type -eq 'GoogleCloudStorage') {
+                                                    $inObj.remove('Service Point')
+                                                    $inObj.remove('Amazon S3 Folder')
+                                                    $inObj.remove('Immutability Period')
+                                                    $inObj.add('Folder Name', $ObjectRepo.Folder)
+                                                    $inObj.add('Enable Nearline Storage Class', $ObjectRepo.EnableNearlineStorageClass)
+                                                    $inObj.add('Enable Coldline Storage Class', $ObjectRepo.EnableColdlineStorageClass)
                                                 }
                                                 $OutObj = [pscustomobject](ConvertTo-HashToYN $inObj)
 

--- a/Src/Private/Get-AbrVbrReplFailoverPlan.ps1
+++ b/Src/Private/Get-AbrVbrReplFailoverPlan.ps1
@@ -6,7 +6,7 @@ function Get-AbrVbrReplFailoverPlan {
     .DESCRIPTION
         Documents the configuration of Veeam VBR in Word/HTML/Text formats using PScribo.
     .NOTES
-        Version:        0.8.12
+        Version:        0.8.13
         Author:         Jonathan Colon
         Twitter:        @jcolonfzenpr
         Github:         rebelinux
@@ -27,7 +27,7 @@ function Get-AbrVbrReplFailoverPlan {
     process {
         if ($FailOverPlans = Get-VBRFailoverPlan | Sort-Object -Property Name) {
             Section -Style Heading3 'Failover Plans' {
-                Paragraph "The following section details failover plan information from Veeam Server $(((Get-VBRServerSession).Server))."
+                Paragraph "The following section details failover plan information from Veeam Server $VeeamBackupServer."
                 $OutObj = @()
                 foreach ($FailOverPlan in $FailOverPlans) {
                     try {
@@ -49,7 +49,7 @@ function Get-AbrVbrReplFailoverPlan {
                             }
 
                             if ($HealthCheck.Replication.BestPractice) {
-                                $OutObj | Where-Object { $Null -like $_.'Description' } | Set-Style -Style Warning -Property 'Description'
+                                $OutObj | Where-Object { $_.'Description' -eq "--" } | Set-Style -Style Warning -Property 'Description'
                                 $OutObj | Where-Object { $_.'Description' -match "Created by" } | Set-Style -Style Warning -Property 'Description'
                             }
 
@@ -63,8 +63,7 @@ function Get-AbrVbrReplFailoverPlan {
                             }
                             $OutObj | Table @TableParams
                             if ($HealthCheck.Replication.BestPractice) {
-                                if ($OutObj | Where-Object { $_.'Description' -match 'Created by' -or $Null -like $_.'Description' }) {
-                                    Paragraph "Health Check:" -Bold -Underline
+                                if ($OutObj | Where-Object { $_.'Description' -match 'Created by' -or $_.'Description' -eq '--' }) {                                    Paragraph "Health Check:" -Bold -Underline
                                     BlankLine
                                     Paragraph {
                                         Text "Best Practice:" -Bold

--- a/Src/Private/Get-AbrVbrReplReplica.ps1
+++ b/Src/Private/Get-AbrVbrReplReplica.ps1
@@ -6,7 +6,7 @@ function Get-AbrVbrReplReplica {
     .DESCRIPTION
         Documents the configuration of Veeam VBR in Word/HTML/Text formats using PScribo.
     .NOTES
-        Version:        0.8.12
+        Version:        0.8.13
         Author:         Jonathan Colon
         Twitter:        @jcolonfzenpr
         Github:         rebelinux
@@ -29,7 +29,7 @@ function Get-AbrVbrReplReplica {
             if ($Replicas = Get-VBRReplica | Sort-Object -Property VmName) {
                 if ($InfoLevel.Replication.Replica -eq 1) {
                     Section -Style Heading3 'Replicas' {
-                        Paragraph "The following section details replica information from Veeam Server $(((Get-VBRServerSession).Server))."
+                        Paragraph "The following section details replica information from Veeam Server $VeeamBackupServer."
                         BlankLine
                         $OutObj = @()
                         foreach ($Replica in $Replicas) {
@@ -62,7 +62,7 @@ function Get-AbrVbrReplReplica {
                 if ($InfoLevel.Replication.Replica -ge 2) {
                     try {
                         Section -Style Heading3 'Replicas' {
-                            Paragraph "The following section details replica information from Veeam Server $(((Get-VBRServerSession).Server))."
+                            Paragraph "The following section details replica information from Veeam Server $VeeamBackupServer."
                             BlankLine
                             $OutObj = @()
                             foreach ($Replica in $Replicas) {

--- a/Src/Private/Get-AbrVbrSecurityCompliance.ps1
+++ b/Src/Private/Get-AbrVbrSecurityCompliance.ps1
@@ -6,7 +6,7 @@ function Get-AbrVbrSecurityCompliance {
     .DESCRIPTION
         Documents the configuration of Veeam VBR in Word/HTML/Text formats using PScribo.
     .NOTES
-        Version:        0.8.12
+        Version:        0.8.13
         Author:         Jonathan Colon
         Twitter:        @jcolonfzenpr
         Github:         rebelinux
@@ -74,6 +74,7 @@ function Get-AbrVbrSecurityCompliance {
                     'LsassProtectedProcess' = 'Local Security Authority Server Service (LSASS) should be set to run as a protected process'
                     'HardenedRepositoryNotContainsNBDProxies' = 'Hardened repositories should not be used as backup proxy servers due to expanded attack surface'
                     'PostgreSqlUseRecommendedSettings' = 'PostgreSQL server should be configured with recommended settings'
+                    'PasswordsComplexityRules' = 'Backup encryption password length and complexity recommendations should be followed'
                 }
                 $StatusObj = @{
                     'Ok' = "Passed"
@@ -86,7 +87,7 @@ function Get-AbrVbrSecurityCompliance {
                     try {
                         # Write-PscriboMessage -IsWarning "$($SecurityCompliance.Type) = $($RuleTypes[$SecurityCompliance.Type.ToString()])"
                         $inObj = [ordered] @{
-                            'Best Practice' = $RuleTypes[$SecurityCompliance.Type.ToString()]
+                            'Best Practices' = $RuleTypes[$SecurityCompliance.Type.ToString()]
                             'Status' = $StatusObj[$SecurityCompliance.Status.ToString()]
                         }
                         $OutObj += [pscustomobject](ConvertTo-HashToYN $inObj)
@@ -124,7 +125,7 @@ function Get-AbrVbrSecurityCompliance {
 
                 $sampleDataObj = $sampleData.GetEnumerator() | Select-Object @{ Name = 'Category'; Expression = { $_.key } }, @{ Name = 'Value'; Expression = { $_.value } }
 
-                $chartFileItem = Get-ColumnChart -Status -SampleData $sampleDataObj -ChartName 'SecurityCompliance' -XField 'Category' -YField 'Value' -ChartAreaName 'Infrastructure' -AxisXTitle 'Status' -AxisYTitle 'Count' -ChartTitleName 'SecurityCompliance' -ChartTitleText 'Best Practice'
+                $chartFileItem = Get-ColumnChart -Status -SampleData $sampleDataObj -ChartName 'SecurityCompliance' -XField 'Category' -YField 'Value' -ChartAreaName 'Infrastructure' -AxisXTitle 'Status' -AxisYTitle 'Count' -ChartTitleName 'SecurityCompliance' -ChartTitleText 'Best Practices'
 
             } catch {
                 Write-PScriboMessage -IsWarning "Security & Compliance chart section: $($_.Exception.Message)"
@@ -136,7 +137,7 @@ function Get-AbrVbrSecurityCompliance {
                         Image -Text 'Security & Compliance - Chart' -Align 'Center' -Percent 100 -Base64 $chartFileItem
                     }
                     BlankLine
-                    $OutObj | Sort-Object -Property 'Best Practice' | Table @TableParams
+                    $OutObj | Sort-Object -Property 'Best Practices' | Table @TableParams
                 }
             }
         } catch {

--- a/Src/Private/Get-AbrVbrTapeMediaPool.ps1
+++ b/Src/Private/Get-AbrVbrTapeMediaPool.ps1
@@ -6,7 +6,7 @@ function Get-AbrVbrTapeMediaPool {
     .DESCRIPTION
         Documents the configuration of Veeam VBR in Word/HTML/Text formats using PScribo.
     .NOTES
-        Version:        0.8.12
+        Version:        0.8.13
         Author:         Jonathan Colon
         Twitter:        @jcolonfzenpr
         Github:         rebelinux
@@ -158,8 +158,7 @@ function Get-AbrVbrTapeMediaPool {
                                                         }
                                                         $OutObj | Sort-Object -Property 'Name' | Table @TableParams
                                                         if ($HealthCheck.Tape.BestPractice) {
-                                                            if ($OutObj | Where-Object { $_.'Description' -match 'Created by' -or $Null -like $_.'Description' }) {
-                                                                Paragraph "Health Check:" -Bold -Underline
+                                                            if ($OutObj | Where-Object { $_.'Description' -match 'Created by' -or $_.'Description' -eq '--' }) {                                                                Paragraph "Health Check:" -Bold -Underline
                                                                 BlankLine
                                                                 Paragraph {
                                                                     Text "Best Practice:" -Bold

--- a/Src/Private/Get-AbrVbrTapeServer.ps1
+++ b/Src/Private/Get-AbrVbrTapeServer.ps1
@@ -6,7 +6,7 @@ function Get-AbrVbrTapeServer {
     .DESCRIPTION
         Documents the configuration of Veeam VBR in Word/HTML/Text formats using PScribo.
     .NOTES
-        Version:        0.8.12
+        Version:        0.8.13
         Author:         Jonathan Colon
         Twitter:        @jcolonfzenpr
         Github:         rebelinux
@@ -49,7 +49,7 @@ function Get-AbrVbrTapeServer {
                         }
 
                         if ($HealthCheck.Tape.BestPractice) {
-                            $OutObj | Where-Object { $Null -like $_.'Description' } | Set-Style -Style Warning -Property 'Description'
+                            $OutObj | Where-Object { $_.'Description' -eq "--" } | Set-Style -Style Warning -Property 'Description'
                             $OutObj | Where-Object { $_.'Description' -match "Created by" } | Set-Style -Style Warning -Property 'Description'
                         }
 
@@ -64,8 +64,7 @@ function Get-AbrVbrTapeServer {
                         }
                         $OutObj | Sort-Object -Property 'Name' | Table @TableParams
                         if ($HealthCheck.Tape.BestPractice) {
-                            if ($OutObj | Where-Object { $_.'Description' -match 'Created by' -or $Null -like $_.'Description' }) {
-                                Paragraph "Health Check:" -Bold -Underline
+                            if ($OutObj | Where-Object { $_.'Description' -match 'Created by' -or $_.'Description' -eq '--' }) {                                Paragraph "Health Check:" -Bold -Underline
                                 BlankLine
                                 Paragraph {
                                     Text "Best Practice:" -Bold

--- a/Src/Private/Get-AbrVbrTapeVault.ps1
+++ b/Src/Private/Get-AbrVbrTapeVault.ps1
@@ -6,7 +6,7 @@ function Get-AbrVbrTapeVault {
     .DESCRIPTION
         Documents the configuration of Veeam VBR in Word/HTML/Text formats using PScribo.
     .NOTES
-        Version:        0.8.12
+        Version:        0.8.13
         Author:         Jonathan Colon
         Twitter:        @jcolonfzenpr
         Github:         rebelinux
@@ -47,7 +47,7 @@ function Get-AbrVbrTapeVault {
                             }
 
                             if ($HealthCheck.Tape.BestPractice) {
-                                $OutObj | Where-Object { $Null -like $_.'Description' } | Set-Style -Style Warning -Property 'Description'
+                                $OutObj | Where-Object { $_.'Description' -eq "--" } | Set-Style -Style Warning -Property 'Description'
                                 $OutObj | Where-Object { $_.'Description' -match "Created by" } | Set-Style -Style Warning -Property 'Description'
                             }
 
@@ -62,8 +62,7 @@ function Get-AbrVbrTapeVault {
                             }
                             $OutObj | Table @TableParams
                             if ($HealthCheck.Tape.BestPractice) {
-                                if ($OutObj | Where-Object { $_.'Description' -match 'Created by' -or $Null -like $_.'Description' }) {
-                                    Paragraph "Health Check:" -Bold -Underline
+                                if ($OutObj | Where-Object { $_.'Description' -match 'Created by' -or $_.'Description' -eq '--' }) {                                    Paragraph "Health Check:" -Bold -Underline
                                     BlankLine
                                     Paragraph {
                                         Text "Best Practice:" -Bold

--- a/Src/Private/Get-AbrVbrUnstructuredDataInfo.ps1
+++ b/Src/Private/Get-AbrVbrUnstructuredDataInfo.ps1
@@ -6,7 +6,7 @@ function Get-AbrVbrUnstructuredDataInfo {
     .DESCRIPTION
         Documents the configuration of Veeam VBR in Word/HTML/Text formats using PScribo.
     .NOTES
-        Version:        0.8.12
+        Version:        0.8.13
         Author:         Jonathan Colon
         Twitter:        @jcolonfzenpr
         Github:         rebelinux
@@ -27,7 +27,7 @@ function Get-AbrVbrUnstructuredDataInfo {
     process {
         if ($ShareObjs = Get-VBRUnstructuredServer) {
             Section -Style Heading3 'Unstructured Data' {
-                Paragraph "The following table provides a summary about the unstructured data backed-up by Veeam Server $(((Get-VBRServerSession).Server))."
+                Paragraph "The following table provides a summary about the unstructured data backed-up by Veeam Server $VeeamBackupServer."
                 $OutObj = @()
                 try {
                     foreach ($ShareObj in $ShareObjs | Where-Object { $_.Type -eq "FileServer" }) {

--- a/Src/Private/Get-AbrVbrVirtualInfrastructure.ps1
+++ b/Src/Private/Get-AbrVbrVirtualInfrastructure.ps1
@@ -6,7 +6,7 @@ function Get-AbrVbrVirtualInfrastructure {
     .DESCRIPTION
         Documents the configuration of Veeam VBR in Word/HTML/Text formats using PScribo.
     .NOTES
-        Version:        0.8.12
+        Version:        0.8.13
         Author:         Jonathan Colon
         Twitter:        @jcolonfzenpr
         Github:         rebelinux
@@ -28,7 +28,7 @@ function Get-AbrVbrVirtualInfrastructure {
         try {
             if ($VbrServer = Get-VBRServer) {
                 Section -Style Heading3 'Virtual Infrastructure' {
-                    Paragraph "The following sections detail the configuration about managed virtual servers backed-up by Veeam Server $(((Get-VBRServerSession).Server))."
+                    Paragraph "The following sections detail the configuration about managed virtual servers backed-up by Veeam Server $VeeamBackupServer."
                     BlankLine
                     #---------------------------------------------------------------------------------------------#
                     #                            VMware vSphere information Section                               #
@@ -36,7 +36,7 @@ function Get-AbrVbrVirtualInfrastructure {
                     try {
                         if ($VbrServer | Where-Object { $_.Type -eq 'VC' -or $_.Type -eq 'ESXi' }) {
                             Section -Style Heading4 'VMware vSphere' {
-                                Paragraph "The following section details information about VMware Virtual Infrastructure backed-up by Veeam Server $(((Get-VBRServerSession).Server))."
+                                Paragraph "The following section details information about VMware Virtual Infrastructure backed-up by Veeam Server $VeeamBackupServer."
                                 BlankLine
                                 $InventObjs = $VbrServer | Where-Object { $_.Type -eq 'VC' }
                                 if ($InventObjs) {

--- a/Src/Private/SharedUtilsFunctions.ps1
+++ b/Src/Private/SharedUtilsFunctions.ps1
@@ -969,7 +969,7 @@ function ConvertTo-HashToYN {
     .DESCRIPTION
 
     .NOTES
-        Version:        0.1.0
+        Version:        0.2.0
         Author:         Jonathan Colon
 
     .EXAMPLE
@@ -978,15 +978,15 @@ function ConvertTo-HashToYN {
 
     #>
     [CmdletBinding()]
-    [OutputType([Hashtable])]
+    [OutputType([System.Collections.Specialized.OrderedDictionary])]
     Param (
         [Parameter (Position = 0, Mandatory)]
         [AllowEmptyString()]
-        [Hashtable] $TEXT
+        [System.Collections.Specialized.OrderedDictionary] $TEXT
     )
 
     $result = [ordered] @{}
-    foreach ($i in $inObj.GetEnumerator()) {
+    foreach ($i in $TEXT.GetEnumerator()) {
         try {
             $result.add($i.Key, (ConvertTo-TextYN $i.Value))
         } catch {

--- a/Src/Public/Invoke-AsBuiltReport.Veeam.VBR.ps1
+++ b/Src/Public/Invoke-AsBuiltReport.Veeam.VBR.ps1
@@ -109,9 +109,9 @@ function Invoke-AsBuiltReport.Veeam.VBR {
                     Paragraph "The following section details configuration information about the Backup Server: $($VeeamBackupServer)"
                     BlankLine
                     if ($InfoLevel.Infrastructure.BackupServer -ge 1) {
-                        # Get-AbrVbrInfrastructureSummary
+                        Get-AbrVbrInfrastructureSummary
                         if ($VbrVersion -ge 12) {
-                            # Get-AbrVbrSecurityCompliance
+                            Get-AbrVbrSecurityCompliance
                         }
                         Get-AbrVbrBackupServerInfo
                         Get-AbrVbrEnterpriseManagerInfo

--- a/Src/Public/Invoke-AsBuiltReport.Veeam.VBR.ps1
+++ b/Src/Public/Invoke-AsBuiltReport.Veeam.VBR.ps1
@@ -109,9 +109,9 @@ function Invoke-AsBuiltReport.Veeam.VBR {
                     Paragraph "The following section details configuration information about the Backup Server: $($VeeamBackupServer)"
                     BlankLine
                     if ($InfoLevel.Infrastructure.BackupServer -ge 1) {
-                        Get-AbrVbrInfrastructureSummary
+                        # Get-AbrVbrInfrastructureSummary
                         if ($VbrVersion -ge 12) {
-                            Get-AbrVbrSecurityCompliance
+                            # Get-AbrVbrSecurityCompliance
                         }
                         Get-AbrVbrBackupServerInfo
                         Get-AbrVbrEnterpriseManagerInfo


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

### [0.8.13] - 2024-12-11

#### Added

- Add EntraID Tenant configuration
  - Add Objects Backup Job information
- Update Malware detection setting
  - Add Signature Detection
- Update Security & Compliance Best Practice content
- Add Syslog Event Filter information
- Add Google Cloud Storage repository information

#### Changed

- Increase Veeam.Diagrammer minimum requirement to v0.6.18
- Change the infrastructure diagram default save location to $OutputFolderPath
- Increase AsBuiltReport.Core to v1.4.1

#### Fixed

- Fix error "A positional parameter cannot be found that accepts argument '-'" at Get-AbrVbrConfigurationBackupSetting cmdlet
- Fix ConvertTo-HashToYN cmdlet not generating an ordereddictionary output

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
