### PR TITLE
V13 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add sponsor information to the module header
 - Add initial support for Veeam Backup & Replication v13 on Windows systems
 - Add timeout handling for vSphere inventory queries
+- Add additional security compliance checks for Veeam VBR Linux appliance
 
 ### Changed
 

--- a/Src/Private/Get-AbrVbrSecurityCompliance.ps1
+++ b/Src/Private/Get-AbrVbrSecurityCompliance.ps1
@@ -85,6 +85,21 @@ function Get-AbrVbrSecurityCompliance {
                     'HardenedRepositoryNotContainsNBDProxies' = 'Hardened repositories should not be used as backup proxy servers due to expanded attack surface'
                     'PostgreSqlUseRecommendedSettings' = 'PostgreSQL server should be configured with recommended settings'
                     'PasswordsComplexityRules' = 'Backup encryption password length and complexity recommendations should be followed'
+                    'FirewallEnabled' = 'Firewall should be enabled'
+                    'EncryptionPasswordsComplexityRules' = 'Local accounts credentials should follow password length and complexity recommendations'
+                    'CredentialsPasswordsComplexityRules' = 'Credentials and encryption passwords should be rotated at least annually'
+                    'CredentialsGuardConfigured' = 'Credentials Guard should be configured'
+                    'LinuxAuditBinariesOwnerIsRoot' = 'Audit binaries should be owned by root'
+                    'LinuxAuditdConfigured' = 'Audits should be enabled and configured to forward audit logs'
+                    'LinuxDisableProblematicServices' = 'Services with known issues should be disabled'
+                    'LinuxOsHasVaRandomization' = 'Address space layout randomization (ASLR) should be used'
+                    'LinuxOsIsFipsEnabled' = 'OS should be in FIPS mode'
+                    'LinuxOsUsesTcpSyncookies'= 'OS should be configured to use TCP syncookies'
+                    'LinuxUsePasswordPolicy' = 'Linux servers should have password-based authentication disabled'
+                    'SecureBootEnable' = 'Secure Boot should be enabled'
+                    'LinuxUseSecurityModule' = 'System should use a security module'
+                    'LinuxWorldDirectoriesPermissions' = 'World-writable directories should not be executable'
+                    'BackupServerHighAvailabilityEnabled' = 'High Availability cluster should be configured for this backup server'
                 }
                 $StatusObj = @{
                     'Ok' = "Passed"

--- a/TODO.md
+++ b/TODO.md
@@ -8,6 +8,6 @@
     - [x] Backup Proxy	(Unknown)
     - [ ] Validate Data Transfer (Wan Accelerators)
     - [x] Backup Repository	(Snap mode)
-- [ ] Fix Security & Compliance Best Practices section
+- [x] Fix Security & Compliance Best Practices section
 - [ ] Fix Immutability Supported column in Repositories table
 - [ ] Fix Storage-Level Corruption Guard (SLCG)


### PR DESCRIPTION
## [0.8.24] - Unreleased

### Added

- Add dependency version check
- Add sponsor information to the module header
- Add initial support for Veeam Backup & Replication v13 on Windows systems
- Add timeout handling for vSphere inventory queries
- Add additional security compliance checks for Veeam VBR Linux appliance

### Changed

- Update module version to v0.8.24
- Upgrade Veeam.Diagrammer module to v0.6.36
- Upgrade Diagrammer.Core module to v0.2.35
- Update GitHub release workflow to use latest checkout action version
- Update GitHub release workflow to use latest bluesky-post-action version
- Update GitHub CodeQL workflow to use latest checkout action version
- Refactor Veeam Backup & Replication scripts to improve server information retrieval
- Update TODO list with new tasks for security and compliance improvements
