### PR TITLE
v0.8.26

### DIFF
--- a/AsBuiltReport.Veeam.VBR.psd1
+++ b/AsBuiltReport.Veeam.VBR.psd1
@@ -55,7 +55,7 @@
     RequiredModules = @(
         @{
             ModuleName = 'AsBuiltReport.Core';
-            ModuleVersion = '1.6.1'
+            ModuleVersion = '1.6.2'
         }
         @{
             ModuleName = 'PScriboCharts';

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ##### This project is community maintained and has no sponsorship from Veeam, its employees or any of its affiliates.
 
-## [0.8.26] - Unreleased
+## [0.8.26] - 2026-02-20
 
 ### :arrows_clockwise: Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### :arrows_clockwise: Changed
 
 - Update module version to `v0.8.26`
+- Upgrade AsBuiltReport.Core module to `v1.6.2`
 - Modify entity retrieval functions for improved timeout handling
 - Add timeout handling for vSphere inventory queries
+- Enable Nutanix Backup Job information collection
+
+### :bug: Fixed
+
+- Fix issue preventing the report to complete
 
 ## [0.8.25] - 2026-01-29
 

--- a/Src/Private/Report/Get-AbrVbrRequiredModule.ps1
+++ b/Src/Private/Report/Get-AbrVbrRequiredModule.ps1
@@ -5,7 +5,7 @@ function Get-AbrVbrRequiredModule {
     .DESCRIPTION
         Documents the configuration of Veeam VBR in Word/HTML/Text formats using PScribo.
     .NOTES
-        Version:        0.8.24
+        Version:        0.8.26
         Author:         Jonathan Colon
         Twitter:        @jcolonfzenpr
         Github:         rebelinux


### PR DESCRIPTION
## [0.8.26] - 2026-02-20

### :arrows_clockwise: Changed

- Update module version to `v0.8.26`
- Upgrade AsBuiltReport.Core module to `v1.6.2`
- Modify entity retrieval functions for improved timeout handling
- Add timeout handling for vSphere inventory queries
- Enable Nutanix Backup Job information collection

### :bug: Fixed

- Fix issue preventing the report to complete